### PR TITLE
Add ability to load POD from URL on initial page load

### DIFF
--- a/lib/PODWebView.pm
+++ b/lib/PODWebView.pm
@@ -6,14 +6,28 @@ use Dancer::Plugin::Preprocess::Markdown;
 use Cwd qw(abs_path);
 use Pod::Simple::HTML;
 
-our $VERSION = '0.1';
+our $VERSION = '0.2';
 
 use Pod::Simple::HTML;
 my $p = Pod::Simple::HTML->new;
 
 get '/' => sub {
+    my $url = param 'url';
+    my $url_content;
+    if ($url) {
+        require HTTP::Tiny;
+        my $response = HTTP::Tiny->new->get($url);
+        if ($response->{success}) {
+            require Encode;
+            require JavaScript::Value::Escape;
+            $url_content = JavaScript::Value::Escape::js(
+                Encode::decode('UTF-8',$response->{content})
+            );
+        }
+    }
     template 'index', {
-        file_size_limit => config->{app_settings}->{file_size_limit}
+        file_size_limit => config->{app_settings}->{file_size_limit},
+        pod_data => $url_content ? "'$url_content'" : "''",
     };
 };
 

--- a/views/index.tt
+++ b/views/index.tt
@@ -147,8 +147,8 @@ function checkFileSize(file) {
 }
 
 $(function () {
-    function fileUploaded(pod) {
-        if ($('#file-load-source').is(':checked')) {
+    function fileUploaded(pod, load_anyway = 0) {
+        if ($('#file-load-source').is(':checked') || load_anyway) {
             editor.getSession().setValue(pod, -1);
         }
     }
@@ -264,6 +264,12 @@ $(function () {
             $('.modal-header').outerHeight() -
             parseInt($('.modal-body').css('padding-top')) * 2);
     });
+
+    // Load POD data is it was passed in via 'url' parameter
+    var pod_data = unescape(<% pod_data %>);
+    if (pod_data) {
+        submitPod(pod_data, function(pod){ fileUploaded(pod, 1) });
+    }
 });
 </script>
 


### PR DESCRIPTION
I think it's good to have a way to pass in a URL to a POD file and for it to be automatically loaded. This way people can share their work before uploading it to CPAN -- to get it reviewed, or for collaboration. For example, a module can be on GitHub, and author can send someone a link to the POD Web View site with a URL parameter of a pointing to the _raw_ file on GitHub -- and the recipient will not need to do any manual steps to upload the file, and can immediately start reviewing it.